### PR TITLE
Improve benchmark ergonomics

### DIFF
--- a/benchmarks/benches/generate.rs
+++ b/benchmarks/benches/generate.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, iter::repeat_with};
+use std::iter::repeat_with;
 
 use quickphf_codegen::phf::generate_phf;
 
@@ -6,21 +6,21 @@ use benchmarks::SIZES;
 
 const SEED: u64 = 42;
 
-#[divan::bench(consts = SIZES, max_time = std::time::Duration::from_secs(10))]
+#[divan::bench(consts = SIZES, max_time = 10)]
 fn quickphf<const S: usize>(bencher: divan::Bencher) {
-    let rng = RefCell::new(fastrand::Rng::with_seed(SEED));
+    let mut rng = fastrand::Rng::with_seed(SEED);
 
     bencher
-        .with_inputs(|| repeat_with(|| rng.borrow_mut().u64(..)).take(S).collect())
+        .with_inputs(|| repeat_with(|| rng.u64(..)).take(S).collect())
         .bench_local_refs(|keys: &mut Vec<u64>| generate_phf(keys));
 }
 
-#[divan::bench(consts = SIZES, max_time = std::time::Duration::from_secs(10))]
+#[divan::bench(consts = SIZES, max_time = 10)]
 fn phf<const S: usize>(bencher: divan::Bencher) {
-    let rng = RefCell::new(fastrand::Rng::with_seed(SEED));
+    let mut rng = fastrand::Rng::with_seed(SEED);
 
     bencher
-        .with_inputs(|| repeat_with(|| rng.borrow_mut().u64(..)).take(S).collect())
+        .with_inputs(|| repeat_with(|| rng.u64(..)).take(S).collect())
         .bench_local_refs(|keys: &mut Vec<u64>| phf_generator::generate_hash(keys));
 }
 

--- a/benchmarks/benches/lookup.rs
+++ b/benchmarks/benches/lookup.rs
@@ -1,5 +1,3 @@
-use std::cell::RefCell;
-
 use benchmarks::{PHF_MAPS, QUICKPHF_MAPS, QUICKPHF_RAW_MAPS, SIZES};
 
 const BATCH_SIZE: usize = 1000;
@@ -7,14 +5,14 @@ const SEED: u64 = 42;
 
 #[divan::bench(consts = SIZES, sample_size = 1)]
 fn phf_map<const S: usize>(bencher: divan::Bencher) {
-    let rng = RefCell::new(fastrand::Rng::with_seed(SEED));
+    let mut rng = fastrand::Rng::with_seed(SEED)
 
     let index = SIZES.iter().position(|&s| s == S).unwrap();
     let map = &PHF_MAPS[index];
     let keys = map.keys().copied().collect::<Vec<_>>();
 
     bencher
-        .with_inputs(|| (0..BATCH_SIZE).map(|_| keys[rng.borrow_mut().usize(0..S)]))
+        .with_inputs(|| (0..BATCH_SIZE).map(|_| keys[rng.usize(0..S)]))
         .bench_local_refs(|queries| {
             for query in queries {
                 divan::black_box(map.get(&query).unwrap());
@@ -24,14 +22,14 @@ fn phf_map<const S: usize>(bencher: divan::Bencher) {
 
 #[divan::bench(consts = SIZES, sample_size = 1)]
 fn quickphf_map<const S: usize>(bencher: divan::Bencher) {
-    let rng = RefCell::new(fastrand::Rng::with_seed(SEED));
+    let mut rng = fastrand::Rng::with_seed(SEED)
 
     let index = SIZES.iter().position(|&s| s == S).unwrap();
     let map = &QUICKPHF_MAPS[index];
     let keys = map.keys().copied().collect::<Vec<_>>();
 
     bencher
-        .with_inputs(|| (0..BATCH_SIZE).map(|_| keys[rng.borrow_mut().usize(0..S)]))
+        .with_inputs(|| (0..BATCH_SIZE).map(|_| keys[rng.usize(0..S)]))
         .bench_local_refs(|queries| {
             for query in queries {
                 divan::black_box(map.get(&query).unwrap());
@@ -41,14 +39,14 @@ fn quickphf_map<const S: usize>(bencher: divan::Bencher) {
 
 #[divan::bench(consts = SIZES, sample_size = 1)]
 fn quickphf_raw_map<const S: usize>(bencher: divan::Bencher) {
-    let rng = RefCell::new(fastrand::Rng::with_seed(SEED));
+    let mut rng = fastrand::Rng::with_seed(SEED)
 
     let index = SIZES.iter().position(|&s| s == S).unwrap();
     let map = &QUICKPHF_RAW_MAPS[index];
     let keys = &QUICKPHF_MAPS[index].keys().copied().collect::<Vec<_>>();
 
     bencher
-        .with_inputs(|| (0..BATCH_SIZE).map(|_| keys[rng.borrow_mut().usize(0..S)]))
+        .with_inputs(|| (0..BATCH_SIZE).map(|_| keys[rng.usize(0..S)]))
         .bench_local_refs(|queries| {
             for query in queries {
                 divan::black_box(map.get(&query));


### PR DESCRIPTION
- Removed unnecessary `RefCell` since `Bencher::bench_local_refs` uses an `FnMut` for its input generation.

- Changed `max_time` to simply use an integer.