### PR TITLE
Use runtime arguments in Divan benchmarks

### DIFF
--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -11,7 +11,7 @@ quickphf = { path = "../quickphf" }
 quickphf_codegen = { path = "../quickphf_codegen" }
 
 [dev-dependencies]
-divan = "0.1.0"
+divan = "0.1.11"
 fastrand = "2.0.1"
 
 [build-dependencies]

--- a/benchmarks/benches/generate.rs
+++ b/benchmarks/benches/generate.rs
@@ -6,21 +6,21 @@ use benchmarks::SIZES;
 
 const SEED: u64 = 42;
 
-#[divan::bench(consts = SIZES, max_time = 10)]
-fn quickphf<const S: usize>(bencher: divan::Bencher) {
+#[divan::bench(args = SIZES, max_time = 10)]
+fn quickphf(bencher: divan::Bencher, size: usize) {
     let mut rng = fastrand::Rng::with_seed(SEED);
 
     bencher
-        .with_inputs(|| repeat_with(|| rng.u64(..)).take(S).collect())
+        .with_inputs(|| repeat_with(|| rng.u64(..)).take(size).collect())
         .bench_local_refs(|keys: &mut Vec<u64>| generate_phf(keys));
 }
 
-#[divan::bench(consts = SIZES, max_time = 10)]
-fn phf<const S: usize>(bencher: divan::Bencher) {
+#[divan::bench(args = SIZES, max_time = 10)]
+fn phf(bencher: divan::Bencher, size: usize) {
     let mut rng = fastrand::Rng::with_seed(SEED);
 
     bencher
-        .with_inputs(|| repeat_with(|| rng.u64(..)).take(S).collect())
+        .with_inputs(|| repeat_with(|| rng.u64(..)).take(size).collect())
         .bench_local_refs(|keys: &mut Vec<u64>| phf_generator::generate_hash(keys));
 }
 

--- a/benchmarks/benches/lookup.rs
+++ b/benchmarks/benches/lookup.rs
@@ -3,16 +3,16 @@ use benchmarks::{PHF_MAPS, QUICKPHF_MAPS, QUICKPHF_RAW_MAPS, SIZES};
 const BATCH_SIZE: usize = 1000;
 const SEED: u64 = 42;
 
-#[divan::bench(consts = SIZES, sample_size = 1)]
-fn phf_map<const S: usize>(bencher: divan::Bencher) {
+#[divan::bench(args = SIZES, sample_size = 1)]
+fn phf_map(bencher: divan::Bencher, size: usize) {
     let mut rng = fastrand::Rng::with_seed(SEED)
 
-    let index = SIZES.iter().position(|&s| s == S).unwrap();
+    let index = SIZES.iter().position(|&s| s == size).unwrap();
     let map = &PHF_MAPS[index];
     let keys = map.keys().copied().collect::<Vec<_>>();
 
     bencher
-        .with_inputs(|| (0..BATCH_SIZE).map(|_| keys[rng.usize(0..S)]))
+        .with_inputs(|| (0..BATCH_SIZE).map(|_| keys[rng.usize(0..size)]))
         .bench_local_refs(|queries| {
             for query in queries {
                 divan::black_box(map.get(&query).unwrap());
@@ -20,16 +20,16 @@ fn phf_map<const S: usize>(bencher: divan::Bencher) {
         })
 }
 
-#[divan::bench(consts = SIZES, sample_size = 1)]
-fn quickphf_map<const S: usize>(bencher: divan::Bencher) {
+#[divan::bench(args = SIZES, sample_size = 1)]
+fn quickphf_map(bencher: divan::Bencher, size: usize) {
     let mut rng = fastrand::Rng::with_seed(SEED)
 
-    let index = SIZES.iter().position(|&s| s == S).unwrap();
+    let index = SIZES.iter().position(|&s| s == size).unwrap();
     let map = &QUICKPHF_MAPS[index];
     let keys = map.keys().copied().collect::<Vec<_>>();
 
     bencher
-        .with_inputs(|| (0..BATCH_SIZE).map(|_| keys[rng.usize(0..S)]))
+        .with_inputs(|| (0..BATCH_SIZE).map(|_| keys[rng.usize(0..size)]))
         .bench_local_refs(|queries| {
             for query in queries {
                 divan::black_box(map.get(&query).unwrap());
@@ -37,16 +37,16 @@ fn quickphf_map<const S: usize>(bencher: divan::Bencher) {
         })
 }
 
-#[divan::bench(consts = SIZES, sample_size = 1)]
-fn quickphf_raw_map<const S: usize>(bencher: divan::Bencher) {
+#[divan::bench(args = SIZES, sample_size = 1)]
+fn quickphf_raw_map(bencher: divan::Bencher, size: usize) {
     let mut rng = fastrand::Rng::with_seed(SEED)
 
-    let index = SIZES.iter().position(|&s| s == S).unwrap();
+    let index = SIZES.iter().position(|&s| s == size).unwrap();
     let map = &QUICKPHF_RAW_MAPS[index];
     let keys = &QUICKPHF_MAPS[index].keys().copied().collect::<Vec<_>>();
 
     bencher
-        .with_inputs(|| (0..BATCH_SIZE).map(|_| keys[rng.usize(0..S)]))
+        .with_inputs(|| (0..BATCH_SIZE).map(|_| keys[rng.usize(0..size)]))
         .bench_local_refs(|queries| {
             for query in queries {
                 divan::black_box(map.get(&query));


### PR DESCRIPTION
The new [`args`](https://docs.rs/divan/latest/divan/attr.bench.html#args) option greatly reduces compile times and is not limited to arrays/slices.